### PR TITLE
Pad 0 fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,6 +166,7 @@ def main():
     stdev[5] = len(peaks)
     stdev[7] = threshold
     best_series_amps = signal[best_peaks]
+    best_diffs_csv = np.append(best_diffs_csv,0)
     combined_array = np.column_stack((timearray,differences,best_series_times_csv,best_diffs_csv,stdev))
     #output_filename = filename[:-4]+".csv"
     logging.info("Saving output values to {}".format(output_filename))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/nginx/html/wtg-app/main.py", line 420, in <module>
    main()
  File "/usr/share/nginx/html/wtg-app/main.py", line 169, in main
    combined_array = np.column_stack((timearray,differences,best_series_times_csv,best_diffs_csv,stdev))
  File "/var/www/.local/lib/python3.10/site-packages/numpy/lib/shape_base.py", line 652, in column_stack
    return _nx.concatenate(arrays, 1)
ValueError: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 8 and the array at index 3 has size 7
```