### PR TITLE
Add a re-run route, rename summary

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -37,6 +37,18 @@ def config(uuid, filename):
 
     return render_template('config.html', uuid=uuid, filename=filename, output_filename=output_filename)
 
+@app.route('/config/<uuid>/', methods=['GET'])
+def rerun(uuid):
+    filename = processes[uuid]
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    os.rename("static/upload/{}/summary.html".format(uuid), "static/upload/{}/summary-{}.html".format(uuid, timestamp))
+    # Call generate_csv here after the user is redirected to the config endpoint
+    #generate_csv(f'static/upload/{uuid}/{uuid}.wav', output_csv, threshold)
+    output_filename = filename[:-4]+".csv"
+    output_filename = output_filename.replace(" ", "_")
+
+    return render_template('config.html', uuid=uuid, filename=filename, output_filename=output_filename)
+
 @app.route('/run/<uuid>/', methods=['POST'])
 def run(uuid):
     filename = str(request.form['filename'])
@@ -49,6 +61,8 @@ def run(uuid):
     rounding = str(request.form['rounding'])
     channel = str(request.form['channelNumber'])
     downsample_rate = str(request.form['downsampleRate'])
+
+    processes[uuid] = filename
 
     debug_command = [
         'python3',
@@ -72,14 +86,6 @@ def run(uuid):
             ]
         debug_command = debug_command + web_mode
 
-    '''
-    debug_command = [
-        'python3',
-        'main.py',
-        '-f', "static/upload/{}/{}".format(uuid, filename),
-        '-o', "static/upload/{}/{}".format(uuid, output_filename)
-    ]
-    '''
 
     print("Running {}".format(debug_command))
 

--- a/web/templates/result.html
+++ b/web/templates/result.html
@@ -122,7 +122,7 @@
 
         <div id="downloadLink">
             <a id="downloadButton" href="/download/{{ uuid }}/{{ output_filename }}">Download {{ output_filename }}</a>
-            <a id="downloadButton" href="/config/{{ uuid }}/{{ output_filename }}">Return to settings</a>
+            <a id="downloadButton" href="/config/{{ uuid }}/">Return to settings</a>
             <a id="homeLink" href="{{ url_for('index') }}">Upload another file</a>
         </div>
 


### PR DESCRIPTION
Adds an undecorated route that checks the processes dict for UUID/filename maps and pulls the correct .wav name when re-visting the config page.

Starts to fill up processes[], and might not (probably won't) during restarts. Ok for now, other option is passing more query params around. 